### PR TITLE
Move non-Windows code behind build tags

### DIFF
--- a/gui.go
+++ b/gui.go
@@ -6,13 +6,8 @@ package gocui
 
 import (
 	standardErrors "errors"
-	"os"
-	"os/signal"
-	"runtime"
 	"strings"
-	"syscall"
 	"time"
-	"unsafe"
 
 	"github.com/go-errors/errors"
 
@@ -100,13 +95,9 @@ type Gui struct {
 func NewGui(mode OutputMode, supportOverlaps bool) (*Gui, error) {
 	g := &Gui{}
 
-	if runtime.GOOS != "windows" {
-		var err error
-		if g.maxX, g.maxY, err = g.getTermWindowSize(); err != nil {
-			return nil, err
-		}
-	} else {
-		g.maxX, g.maxY = termbox.Size()
+	var err error
+	if g.maxX, g.maxY, err = g.getTermWindowSize(); err != nil {
+		return nil, err
 	}
 
 	if err := termbox.Init(); err != nil {
@@ -857,53 +848,4 @@ func (g *Gui) loaderTick() {
 			}
 		}
 	}()
-}
-
-type windowSize struct {
-	rows    uint16
-	cols    uint16
-	xpixels uint16
-	ypixels uint16
-}
-
-// getTermWindowSize is get terminal window size on linux or unix.
-// When gocui run inside the docker contaienr need to check and get the window size.
-func (g *Gui) getTermWindowSize() (int, int, error) {
-	out, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
-	if err != nil {
-		return 0, 0, err
-	}
-	defer out.Close()
-
-	signalCh := make(chan os.Signal, 1)
-	signal.Notify(signalCh, syscall.SIGWINCH, syscall.SIGINT)
-	defer signal.Stop(signalCh)
-
-	var sz windowSize
-
-	for {
-		_, _, err = syscall.Syscall(
-			syscall.SYS_IOCTL,
-			out.Fd(),
-			uintptr(syscall.TIOCGWINSZ),
-			uintptr(unsafe.Pointer(&sz)),
-		)
-
-		// check terminal window size
-		if sz.cols > 0 && sz.rows > 0 {
-			return int(sz.cols), int(sz.rows), nil
-		}
-
-		select {
-		case signal := <-signalCh:
-			switch signal {
-			// when the terminal window size is changed
-			case syscall.SIGWINCH:
-				continue
-			// ctrl + c to cancel
-			case syscall.SIGINT:
-				return 0, 0, errors.New("There was not enough window space to start the application")
-			}
-		}
-	}
 }

--- a/gui_notwin.go
+++ b/gui_notwin.go
@@ -1,0 +1,61 @@
+// +build !windows
+
+package gocui
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+	"unsafe"
+
+	"github.com/go-errors/errors"
+)
+
+type windowSize struct {
+	rows    uint16
+	cols    uint16
+	xpixels uint16
+	ypixels uint16
+}
+
+// getTermWindowSize is get terminal window size on linux or unix.
+// When gocui run inside the docker contaienr need to check and get the window size.
+func (g *Gui) getTermWindowSize() (int, int, error) {
+	out, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
+	if err != nil {
+		return 0, 0, err
+	}
+	defer out.Close()
+
+	signalCh := make(chan os.Signal, 1)
+	signal.Notify(signalCh, syscall.SIGWINCH, syscall.SIGINT)
+	defer signal.Stop(signalCh)
+
+	var sz windowSize
+
+	for {
+		_, _, err = syscall.Syscall(
+			syscall.SYS_IOCTL,
+			out.Fd(),
+			uintptr(syscall.TIOCGWINSZ),
+			uintptr(unsafe.Pointer(&sz)),
+		)
+
+		// check terminal window size
+		if sz.cols > 0 && sz.rows > 0 {
+			return int(sz.cols), int(sz.rows), nil
+		}
+
+		select {
+		case signal := <-signalCh:
+			switch signal {
+			// when the terminal window size is changed
+			case syscall.SIGWINCH:
+				continue
+			// ctrl + c to cancel
+			case syscall.SIGINT:
+				return 0, 0, errors.New("There was not enough window space to start the application")
+			}
+		}
+	}
+}

--- a/gui_win.go
+++ b/gui_win.go
@@ -1,0 +1,10 @@
+// +build windows
+
+package gocui
+
+import "github.com/jesseduffield/termbox-go"
+
+func (g *Gui) getTermWindowSize() (int, int, error) {
+	x, y := termbox.Size()
+	return x, y, nil
+}


### PR DESCRIPTION
Moved non-windows code to new non-windows file so it could be compiled on Windows.